### PR TITLE
Fix docs for refactored API and restore build

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,12 +4,15 @@ push!(LOAD_PATH,"../src/")
 
 format = Documenter.HTML(
     prettyurls = get(ENV, "CI", nothing) == "true",
+    edit_link = "main",
     assets = [joinpath("assets", "logo.ico")],
     size_threshold_ignore = ["library.md"]
 )
 
 makedocs(
     sitename="NeutralAtoms.jl",
+    modules=[NeutralAtoms],
+    checkdocs=:exports,
     format=format,
     authors="M.Y. Goloshchapov",
     pages = [
@@ -21,4 +24,5 @@ makedocs(
 
 deploydocs(
     repo = "https://github.com/mgoloshchapov/NeutralAtoms.jl",
+    devbranch = "main",
 )

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,142 +1,199 @@
 # Examples
 
-## Release and recapture experiment
+The current package API is built around dict-based laser descriptions and an
+`error_options` dictionary that turns physical effects on and off. The examples
+below use lightweight settings so they compile quickly in the documentation
+build while still reflecting the current code paths.
 
-Release and recapture method is used to measure temperature of single neutral atom in optical trap formed by gaussian beam.
+## Release And Recapture
 
-The trap is turned off by a variable amount of time and probability to recapture atom is measured. If we know atom mass and trap parameters, we can extract atom temperature by comparing experimental release and recapture curve with the modelling.
+Release-and-recapture is the package's temperature-estimation entry point for a
+single atom in a Gaussian optical tweezer.
 
-```@example
+```@example recapture
 using NeutralAtoms
 using Plots
+using Random
 
-# Atom and trap parameters
-U0, w0, λ, M2 = 1000.0, 1.1, 0.852, 1.3;
-z0 = w0_to_z0(w0, λ, M2);
-m, T = 86.9091835, 50.0;
-trap_params = [U0, w0, z0];
-atom_params = [m, T];
+Random.seed!(1234)
 
-# Simulation parameters
-tspan = [0.0:1.0:50.0;];
-N = 10000 
+trap_params = [1000.0, 1.1, w0_to_z0(1.1, 0.852, 1.3)]
+atom_params = [86.9091835, 35.0]
+tspan = collect(0.0:2.0:40.0)
 
-# Calculate recapture probabilities
-probs, acc_rate = release_recapture(
-    tspan, 
-    trap_params, 
-    atom_params, 
-    N; 
-    harmonic=false);
+recapture, acc_rate = release_recapture(
+    tspan,
+    trap_params,
+    atom_params,
+    200;
+    harmonic = true,
+)
 
-# Plot release and recapture curve
-plot(tspan, probs, label=false, width=3, color="red")
-xlims!(0.0, 50.0)
-ylims!(0.0, 1.05)
-xlabel!("Time, μs")
+plot(tspan, recapture; lw = 3, label = "recapture")
+xlabel!("Release time (μs)")
 ylabel!("Recapture probability")
+title!("Release-and-recapture curve")
 ```
 
-## Two-photon Rydberg excitation
+## Single-Atom Two-Photon Rydberg Dynamics
 
-Two-photon Rydberg excitation is used, for example, to implement native CZ gate on neutral atom quantum computers. Here we implement modelling of two-photon Rydberg excitation with different sources of decoherence: atom dynamics, laser phase noise, spontaneous decay from intermediate state.
-
-Import necessary modules and specify atom and trap parameters.
+The single-atom simulation path combines thermal motion, Doppler shifts,
+optional phase noise, and spontaneous decay in the style of
+[arXiv:1802.10424](https://arxiv.org/abs/1802.10424).
 
 ```@example rydberg
 using NeutralAtoms
 using QuantumOptics
 using Plots
+using Random
 
+Random.seed!(1234)
 
-m = 86.9091835;   
-T = 50.0;
-U0 = 1000.0;
-w0 = 1.1;
-λ0 = 0.813;
-M2 = 1.3;
-z0 = w0_to_z0(w0, λ0, M2);
-atom_params = [m, T];
-trap_params = [U0, w0, z0];    
+atom_params = [86.9091835, 20.0]
+trap_params = [1000.0, 1.1, w0_to_z0(1.1, 0.813, 1.3)]
 
-nothing #hide
+Ωr = 2π * 8.0
+Ωb = 2π * 8.0
+Δ0 = 2π * 250.0
+
+first_laser_params = Dict(
+    "Ω" => Ωr,
+    "w0" => 10.0,
+    "z0" => w0_to_z0(10.0, 0.795),
+    "θ" => 0.0,
+    "n_sg" => 1,
+    "type" => "gauss",
+)
+second_laser_params = Dict(
+    "Ω" => Ωb,
+    "w0" => 3.5,
+    "z0" => w0_to_z0(3.5, 0.475),
+    "θ" => 0.0,
+    "n_sg" => 1,
+    "type" => "gauss",
+)
+
+f = collect(0.02:0.02:0.10)
+phase_amplitudes = zeros(length(f))
+detuning_params = [Δ0, -δ_twophoton(Ωr, Ωb, Δ0)]
+decay_params = [2π * 0.2, 2π * 0.2, 0.0, 0.0]
+error_options = Dict(
+    "laser_noise" => false,
+    "spontaneous_decay_intermediate" => true,
+    "spontaneous_decay_rydberg" => false,
+    "atom_motion" => true,
+    "free_motion" => true,
+    "xy_motion" => true,
+    "z_motion" => true,
+    "Doppler" => true,
+)
+
+tspan = collect(0.0:0.05:0.35)
+
+cfg = RydbergConfig(
+    tspan,
+    ket_1,
+    atom_params,
+    trap_params,
+    2,
+    f,
+    phase_amplitudes,
+    phase_amplitudes,
+    first_laser_params,
+    second_laser_params,
+    [0.0, 0.0, 0.0],
+    detuning_params,
+    decay_params,
+    error_options,
+)
+
+ρ, ρ2 = simulation(cfg; reltol = 1e-6, abstol = 1e-8)
+rydberg_probs = get_rydberg_probs(ρ, ρ2)
+plot_rydberg_probs(tspan, rydberg_probs)
 ```
 
-Let's now define parameters of laser phase noise. The model for realistic laser phase noise is decribed in [this article](https://arxiv.org/abs/2210.11007) and consists of white noise and two servo bumps. The spectral density is described as
+## Two-Qubit Blockade Simulation
 
-```math
-\begin{aligned}
-    S_{\delta \nu}(f) = h_{0} &+ h_{g1}\exp\left(-\frac{(f-f_{g1})^2}{2\sigma_{g1}^2} \right) + h_{g1}\exp\left(-\frac{(f+f_{g1})^2}{2\sigma_{g1}^2} \right) \\
-    &+ h_{g2}\exp\left(-\frac{(f-f_{g2})^2}{2\sigma_{g2}^2} \right) + h_{g2}\exp\left(-\frac{(f+f_{g2})^2}{2\sigma_{g2}^2} \right).
-\end{aligned}
+`simulation_czlp` extends the same ingredients to a two-atom blockade model in
+the spirit of [arXiv:1908.06101](https://arxiv.org/abs/1908.06101).
+
+```@example cz
+using NeutralAtoms
+using QuantumOptics
+using Plots
+using Random
+
+Random.seed!(1234)
+
+atom_params = [86.9091835, 10.0]
+trap_params = [1000.0, 1.1, w0_to_z0(1.1, 0.813, 1.3)]
+
+Ωr = 2π * 6.0
+Ωb = 2π * 6.0
+Δ0 = 2π * 200.0
+
+first_laser_params = Dict(
+    "Ω" => Ωr,
+    "w0" => 10.0,
+    "z0" => w0_to_z0(10.0, 0.795),
+    "θ" => 0.0,
+    "n_sg" => 1,
+    "type" => "gauss",
+)
+second_laser_params = Dict(
+    "Ω" => Ωb,
+    "w0" => 3.5,
+    "z0" => w0_to_z0(3.5, 0.475),
+    "θ" => 0.0,
+    "n_sg" => 1,
+    "type" => "gauss",
+)
+
+f = collect(0.02:0.02:0.10)
+phase_amplitudes = zeros(length(f))
+detuning_params = [Δ0, -δ_twophoton(Ωr, Ωb, Δ0)]
+decay_params = [2π * 0.1, 2π * 0.1, 0.0, 0.0]
+error_options = Dict(
+    "laser_noise" => false,
+    "spontaneous_decay_intermediate" => true,
+    "spontaneous_decay_rydberg" => false,
+    "atom_motion" => true,
+    "free_motion" => true,
+    "xy_motion" => true,
+    "z_motion" => true,
+    "Doppler" => true,
+)
+
+ket_plus = (ket_0 + ket_1) / sqrt(2)
+tspan = [0.0, 0.05]
+
+cfg = CZLPConfig(
+    tspan,
+    ket_plus ⊗ ket_plus,
+    atom_params,
+    trap_params,
+    1,
+    f,
+    phase_amplitudes,
+    phase_amplitudes,
+    first_laser_params,
+    second_laser_params,
+    detuning_params,
+    decay_params,
+    error_options,
+    [[-2.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+    2π * 500.0 * 4.0^6,
+    1.0,
+    1.0,
+    π / 2,
+    0.0,
+)
+
+ρ, ρ2 = simulation_czlp(cfg; reltol = 1e-6, abstol = 1e-8)
+two_qubit_probs = get_two_qubit_probs(ρ, ρ2)
+plot_two_qubit_probs(tspan, two_qubit_probs)
 ```
 
-After the phase noise spectral density is defined and transformed to $S_{\phi} = S_{\delta \nu}/f^{2}$, we can sample laser phase noise trajectories as
-
-```math
-\phi(t) = \sum_{i} 2\sqrt{S_{\phi}(f_{i})\Delta f}\cos\left(2\pi f_{i} t + \varphi_{i}\right),
-```
-
-where phases $\varphi_{i}$ are sampled from $U[0,2\pi]$.
-
-```@example rydberg
-h0 = 13.0 * 1e-6;    #MHz^2/MHz
-hg1 = 25.0 * 1e-6;   #MHz^2/MHz
-hg2 = 10.0e3 * 1e-6; #MHz^2/MHz
-fg1 = 130.0 * 1e-3;  #MHz
-fg2 = 234.0 * 1e-3;  #MHz
-σg1 = 18.0 * 1e-3;   #MHz
-σg2 = 1.5 * 1e-3;    #MHz
-
-red_laser_phase_params  = [h0, [hg1, hg2], [σg1, σg2], [fg1, fg2]];
-blue_laser_phase_params = [h0, [hg1, hg2], [σg1, σg2], [fg1, fg2]];
-f = [0.01:0.0025:1.0;];
-red_laser_phase_amplitudes = ϕ_amplitudes(f, red_laser_phase_params);
-blue_laser_phase_amplitudes = ϕ_amplitudes(f, blue_laser_phase_params);
-
-nothing #hide
-```
-
-Here we define parameters of excitation beams, detunings and decay parameters.
-
-```@example rydberg
-#Excitation beam parameters
-λr = 0.795;
-λb = 0.475;
-wr = 10.0;
-wb = 3.5;
-zr = w0_to_z0(wr, λr);
-zb = w0_to_z0(wr, λb);
-
-#Rabi frequencies
-Δ0 = 2.0*π * 904.0;
-Ωr = 2π * 60.0;
-Ωb = 2π * 60.0;
-blue_laser_params = [Ωb, wb, zb];
-red_laser_params = [Ωr, wr, zr];
-
-nothing #hide
-```
-
-```@example rydberg
-# Detunings and decay params
-detuning_params = [Δ0, δ_twophoton(Ωr, Ωb, Δ0)];
-Γ = 2.0*π * 6.0;
-decay_params = [Γ/4, 3*Γ/4];
-
-nothing #hide
-```
-
-Now let's define simulation time and draw samples of single atom in optical trap using Metropolis sampler.
-
-```@example rydberg
-# Period of Rabi oscillations
-T0 = T_twophoton(Ωr, Ωb, Δ0);
-tspan = [0.0:T0/30:2.5*T0;];
-
-# Get initial atom coordinates and velocities
-N = 200;
-samples, acc_rate = samples_generate(trap_params, atom_params, N; skip=5000, freq=1000);
-
-nothing #hide
-```
+For phase-gate calibration and fidelity analysis, the main helpers are
+`get_fidelity_with_rz_phi`, `CZ_calibration_by_fidelity_oscillation`,
+`get_parity_osc`, and `get_cz_infidelity`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,24 +3,57 @@
 [![Build Status](https://github.com/mgoloshchapov/NeutralAtoms.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/mgoloshchapov/NeutralAtoms.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://mgoloshchapov.github.io/NeutralAtoms.jl/dev/)
 
-This package provides a set of tools to simulate experiments with neutral atoms.
+`NeutralAtoms.jl` simulates neutral-atom experiments in optical tweezers, with a
+focus on two-photon Rydberg excitation and blockade-mediated controlled-phase
+gates.
+
+The package is organized around the same experimental workflow as the papers
+that motivate it:
+
+- trap characterization and thermal sampling of atom motion
+- release-and-recapture thermometry
+- effective two-photon Rydberg excitation with Doppler shifts
+- stochastic laser phase noise and spontaneous decay channels
+- blockade-mediated two-qubit phase-gate simulation and calibration
 
 ## Installation
 
-Paste the following line into the Julia REPL:
-
-```
-]add "https://github.com/mgoloshchapov/NeutralAtoms.jl"
-```
-
-or
+Install the package directly from GitHub:
 
 ```julia
-using Pkg; Pkg.add(PackageSpec(url="https://github.com/mgoloshchapov/NeutralAtoms.jl"))
+using Pkg
+Pkg.add(PackageSpec(url="https://github.com/mgoloshchapov/NeutralAtoms.jl"))
 ```
 
-## Package features
+## Package Scope
 
-- Simulation of two-photon Rydberg excitation with different sources of decoherence: atom motion, laser phase noise, intermediate state decay
+The current API models:
 
-- Simulation of release and recapture experiment
+- Gaussian tweezer optics and trap frequencies
+- Monte Carlo sampling of thermal positions and velocities
+- time-dependent master-equation simulation for a single atom
+- configurable beam models, including Gaussian and Hermite-Gauss based profiles
+- two-atom blockade simulations for CZ-style global-pulse protocols
+- helper routines for parity scans and infidelity budgets
+
+The single-atom modeling follows the physical picture emphasized in
+[de Léséleuc et al. (2018)](https://arxiv.org/abs/1802.10424): Doppler
+dephasing, spontaneous emission through the intermediate state, and laser phase
+noise. The two-qubit modeling follows the blockade-based global-pulse gate
+protocol of [Levine et al. (2019)](https://arxiv.org/abs/1908.06101).
+
+## Start Here
+
+- Read [Examples](examples.md) for tutorial-style workflows using the current
+  dict-based laser parameter API.
+- Use [API](library.md) for the exported functions and configuration types.
+
+## References
+
+- Sylvain de Léséleuc, Daniel Barredo, Vincent Lienhard, Antoine Browaeys, and
+  Thierry Lahaye, [“Analysis of imperfections in the coherent optical excitation
+  of single atoms to Rydberg states”](https://arxiv.org/abs/1802.10424).
+- Harry Levine, Alexander Keesling, Giulia Semeghini, Ahmed Omran, Tout T.
+  Wang, Sepehr Ebadi, Hannes Bernien, Markus Greiner, Vladan Vuletić, Hannes
+  Pichler, and Mikhail D. Lukin, [“Parallel implementation of high-fidelity
+  multi-qubit gates with neutral atoms”](https://arxiv.org/abs/1908.06101).

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -1,6 +1,91 @@
-# NeutralAtoms.jl Documentation
+# API Reference
 
-```@autodocs
-Modules = [NeutralAtoms]
-Pages = ["basic_experiments.jl", "rydberg_model.jl"]
+```@meta
+CurrentModule = NeutralAtoms
+```
+
+## Package
+
+```@docs
+NeutralAtoms
+```
+
+## Beam And Trap Optics
+
+```@docs
+w0_to_z0
+trap_frequencies
+E
+I
+get_trap_params
+```
+
+## Thermal Sampling And Release/Recapture
+
+```@docs
+H
+samples_generate
+R
+V
+release_recapture
+```
+
+## Laser Phase Noise
+
+```@docs
+Sϕ
+ϕ_amplitudes
+ϕ
+```
+
+## Single-Atom Rydberg Simulation
+
+```@docs
+RydbergConfig
+ket_0
+ket_1
+ket_r
+ket_p
+ket_l
+gauss_field
+simulation
+Ω_twophoton
+T_twophoton
+δ_twophoton
+Ωr_required
+get_rydberg_probs
+plot_rydberg_probs
+```
+
+## Beam Shaping Helpers
+
+```@docs
+simple_flattopHG_field
+simple_flattopLG_field
+HG_coeff
+HG_coefficients
+decomposition_HG_2d
+reconstruct_HG_field_2d
+```
+
+## Two-Qubit CZ Workflow
+
+```@docs
+CZLPConfig
+simulation_czlp
+get_two_qubit_probs
+plot_two_qubit_probs
+get_fidelity_with_rz_phi
+CZ_calibration_by_fidelity_oscillation
+get_parity_osc
+get_rydberg_fidelity_configs
+get_rydberg_infidelity
+get_cz_infidelity
+```
+
+## Gate Utilities
+
+```@docs
+get_gate
+project_on_qubit
 ```

--- a/src/NeutralAtoms.jl
+++ b/src/NeutralAtoms.jl
@@ -32,7 +32,7 @@ export
 
     w0_to_z0, trap_frequencies, E, I,
     release_recapture,
-    samples_generate, R, V, get_trap_params, H, samples_visualise,
+    samples_generate, R, V, get_trap_params, H,
     Sϕ, ϕ_amplitudes, ϕ,
     Ω_twophoton, T_twophoton, δ_twophoton, Ωr_required, 
     ket_0, ket_1, ket_r, ket_p, ket_l,

--- a/src/arbitrary_beams.jl
+++ b/src/arbitrary_beams.jl
@@ -131,6 +131,12 @@ function simple_flattopLG_field(x,y,z,laser_params)
     return Ω .* w0 ./ w .* exp.(-1.0im * phase0) * E_sum
 end
 
+"""decomposition_HG_2d(x, y, F, w, dx, dy; n_max=20, m_max=20)
+
+    Decompose a sampled two-dimensional field profile into a Hermite-Gauss basis.
+
+    The returned coefficient matrix can be passed to `reconstruct_HG_field_2d`.
+"""
 function decomposition_HG_2d(x::Vector{Float64}, y::Vector{Float64}, F::Vector{Float64},
                          w::Float64, dx::Float64, dy::Float64; n_max=20, m_max=20)
     c = zeros(n_max+1, m_max+1); #m_max
@@ -143,6 +149,13 @@ function decomposition_HG_2d(x::Vector{Float64}, y::Vector{Float64}, F::Vector{F
     return c
 end
 
+"""reconstruct_HG_field_2d(x, y, z, Ω_w_z, c_xy)
+
+    Reconstruct a complex Hermite-Gauss beam field from its coefficient matrix
+    `c_xy` at point `(x, y, z)`.
+
+    `Ω_w_z` is expected to contain `[Ω, w0, z0]`.
+"""
 function reconstruct_HG_field_2d(x::Float64,y::Float64,z::Float64, Ω_w_z::Vector{Float64}, c_xy::Matrix{Float64}) 
     #laser_params::Dict{String, Any}) ## cy::Vector{Float64}
     #c_xy = laser_params["coeffs_xy"]
@@ -174,4 +187,4 @@ function reconstruct_HG_field_2d(x::Float64,y::Float64,z::Float64, Ω_w_z::Vecto
 end;
 
 #function decomposition_IG(x::Vector{Float64}, y::Vector{Float64}, F::Vector{Float64}, w::Float64, dx::Float64, dy::Float64; n_max=20, m_max=20)
-#function reconstruct_IG_field(x::Float64,y::Float64,z::Float64, Ω_w_z::Vector{Float64}, coeffs::Matrix{Float64}) 
+#function reconstruct_IG_field(x::Float64,y::Float64,z::Float64, Ω_w_z::Vector{Float64}, coeffs::Matrix{Float64})

--- a/src/fidelity.jl
+++ b/src/fidelity.jl
@@ -1,4 +1,12 @@
 
+"""get_fidelity_with_rz_phi(ρ, state, ϕ_rz)
+
+    Return the fidelity with a target state after applying a global two-qubit
+    `RZ(ϕ_rz) ⊗ RZ(ϕ_rz)` correction.
+
+    This helper is used when calibrating the phase of the blockade-mediated CZ
+    sequence.
+"""
 function get_fidelity_with_rz_phi(ρ, state, ϕ_rz)
     ones = ket_1 ⊗ ket_1
     CZ = Id ⊗ Id - 2*(ones ⊗ dagger(ones));
@@ -35,7 +43,7 @@ function CZ_calibration_by_fidelity_oscillation(cfg::CZLPConfig; ode_kwargs...)
     return ϕ_list, F_list, ϕ_list[argmax(F_list)]
 end
 
-"""get_parity_osc(cfg::CZLPConfig, ϕ_cal; ode_kwargs...)
+"""get_parity_osc(ρ, ϕ_cal)
 
     Compute the parity oscillation expected after applying the CZ sequence and the
     phase correction `ϕ_cal`.
@@ -50,7 +58,7 @@ function get_parity_osc(ρ, ϕ_cal)
     θ = ϕ_cal; # - cfg_parity.ϕ_RZ + ϕ_cal - π
     U = a -> global_RX(π/2) * global_RZ(a) * global_RX(5*π/4)
 
-    Par_list = [real(expect(S_ZZ , U(ϕ) * (θ) * ρ * dagger(U(ϕ) * global_RZ(θ)) ) ) for ϕ in ϕ_list];
+    Par_list = [real(expect(S_ZZ, U(ϕ) * global_RZ(θ) * ρ * dagger(U(ϕ) * global_RZ(θ)))) for ϕ in ϕ_list];
     #use plot(ϕ_list, Par_list) in notebook 
     return ϕ_list, Par_list 
 end 
@@ -192,7 +200,7 @@ function get_cz_infidelity(
     cfg_t.n_samples                         = 1
 
     println("Measuring intermediate state probability...")
-    ϕ_RZ = get_parity_fidelity(cfg_t)[3];
+    ϕ_RZ = CZ_calibration_by_fidelity_oscillation(cfg_t)[3];
     global_RZ = RZ(ϕ_RZ) ⊗ RZ(ϕ_RZ);
 
     cfg_t.ψ0 = ket_pos ⊗ ket_pos

--- a/src/rydberg_model.jl
+++ b/src/rydberg_model.jl
@@ -68,6 +68,14 @@ const operators = [np, nr, σ1p, σp1, σpr, σrp];
     return X, Y, Z, Vx, Vy, Vz;
 end
 
+"""gauss_field(x, y, z, w0, z0; n0=1, θ0=0)
+
+    Return the normalized complex Gaussian field envelope used by the refactored
+    dict-based beam parameter API.
+
+    This is the Gaussian-beam specialization that `Ω` uses when
+    `laser_params["type"] == "gauss"`.
+"""
 @inline function gauss_field(x, y, z, w0, z0; n0=1, θ0=0)
     return A(x, y, z, w0, z0; n=n0, θ=θ0) .* A_phase(x, y, z, w0, z0; θ=θ0)
 end;
@@ -314,14 +322,14 @@ function simulation(
 end;
 
 
-@doc doc"""
+"""
     Ω_twophoton(Ωr, Ωb, Δ)
 
-    Return the effective two-photon Rabi frequency
+Return the effective two-photon Rabi frequency
 
-    ```math
-    \Omega_{\mathrm{2ph}} = \left| \frac{\Omega_r \Omega_b}{2 \Delta} \right|.
-    ```
+```math
+\\Omega_{\\mathrm{2ph}} = \\left| \\frac{\\Omega_r \\Omega_b}{2 \\Delta} \\right|.
+```
 """
 function Ω_twophoton(Ωr, Ωb, Δ)
     return abs(Ωb * Ωr / (2.0 * Δ))
@@ -341,14 +349,12 @@ end;
 """
     δ_twophoton(Ωr, Ωb, Δ)
 
-    Return the differential AC Stark shift of the effective two-photon transition:
+Return the differential AC Stark shift of the effective two-photon transition:
 
-    ```math
-    """
-    #\delta_{\mathrm{2ph}} = \frac{|\Omega_r|^2 - |\Omega_b|^2}{4 \Delta}.
-    """
-    ```
-""" 
+```math
+\\delta_{\\mathrm{2ph}} = \\frac{|\\Omega_r|^2 - |\\Omega_b|^2}{4 \\Delta}.
+```
+"""
 function δ_twophoton(Ωr, Ωb, Δ)
     return (abs(Ωr)^2 - abs(Ωb)^2)/(4.0 * Δ)
 end;
@@ -374,8 +380,8 @@ end;
 """
 function calibrate_two_photon(cfg::RydbergConfig, n_samples=1000)
     cfg_calibrated = deepcopy(cfg)
-    Ωr = cfg.first_laser_params[1]
-    Ωb = cfg.second_laser_params[1]
+    Ωr = cfg.first_laser_params["Ω"]
+    Ωb = cfg.second_laser_params["Ω"]
 
     samples = samples_generate(cfg.trap_params, cfg.atom_params, n_samples)[1]
 
@@ -383,8 +389,8 @@ function calibrate_two_photon(cfg::RydbergConfig, n_samples=1000)
     samples_Ω2 = [Ω_twophoton(Ω(x, y, z, cfg_calibrated.first_laser_params), Ω(x, y, z, cfg_calibrated.second_laser_params), Δ(vx, vz, cfg_calibrated.first_laser_params)) for (x, y, z, vx, _, vz) in samples]
     factor_Ω2 = sqrt((sum(samples_Ω2) / length(samples)) / Ω_twophoton(Ωr, Ωb, cfg.detuning_params[1]))
     Ωr_cor, Ωb_cor = Ωr / factor_Ω2, Ωb / factor_Ω2
-    cfg_calibrated.first_laser_params[1]  = Ωr_cor
-    cfg_calibrated.second_laser_params[1] = Ωb_cor
+    cfg_calibrated.first_laser_params["Ω"]  = Ωr_cor
+    cfg_calibrated.second_laser_params["Ω"] = Ωb_cor
 
     # Correct resonance detuning to match temperature averaged AC Stark shifts
     samples_δ = [δ_twophoton(Ω(x, y, z, cfg_calibrated.first_laser_params), Ω(x, y, z, cfg_calibrated.second_laser_params), Δ(vx, vz, cfg_calibrated.first_laser_params)) for (x, y, z, vx, _, vz) in samples]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -6,27 +6,25 @@ function w(z, w0, z0)
     return w0 .* sqrt.(1.0 .+ (z ./z0) .^2);
 end;
 
-@doc doc"""
+"""
     w0_to_z0(w0, λ, M2=1.0)
 
-    Return the Rayleigh length associated with a beam waist `w0`.
+Return the Rayleigh length associated with a beam waist `w0`.
 
-    The conversion is
+The conversion is
 
-    ```math
-    z_0 = \frac{pi w_0^2}{lambda M^2}.
-    ```
+```math
+z_0 = \\frac{\\pi w_0^2}{\\lambda M^2}.
+```
 
-    # Arguments
-    - `w0`: beam waist radius in `μm`.
-    - `λ`: beam wavelength in `μm`.
-    - `M2 = 1.0`: beam-quality factor. `M2 = 1` corresponds to an ideal Gaussian
-    beam.
+# Arguments
+- `w0`: beam waist radius in `μm`.
+- `λ`: beam wavelength in `μm`.
+- `M2 = 1.0`: beam-quality factor. `M2 = 1` corresponds to an ideal Gaussian beam.
 
-    # Returns
-    - Rayleigh length in `μm`.
+# Returns
+- Rayleigh length in `μm`.
 """
-
 function w0_to_z0(w0, λ, M2=1.0)
     return π*w0^2/λ / M2;
 end;
@@ -213,22 +211,22 @@ end
     in `μm`.
     - `n_samples::Int64`: number of Monte Carlo trajectories to average.
     - `f::Vector{Float64}`: phase-noise frequency grid in `MHz`.
-    - `red_laser_phase_amplitudes::Vector{Float64}`: Fourier amplitudes for the
-    red-laser phase-noise trace.
-    - `blue_laser_phase_amplitudes::Vector{Float64}`: Fourier amplitudes for the
-    blue-laser phase-noise trace.
-    - `red_laser_params::Vector{Float64}`: red-laser coupling and beam parameters.
-    - `blue_laser_params::Vector{Float64}`: blue-laser coupling and beam parameters.
+    - `first_laser_phase_amplitudes::Vector{Float64}`: Fourier amplitudes for the
+    first-laser phase-noise trace.
+    - `second_laser_phase_amplitudes::Vector{Float64}`: Fourier amplitudes for the
+    second-laser phase-noise trace.
+    - `first_laser_params::Dict{String, Any}`: dict-based description of the first
+    laser beam and coupling.
+    - `second_laser_params::Dict{String, Any}`: dict-based description of the second
+    laser beam and coupling.
+    - `shift::Vector{Float64}`: static spatial shift applied to the sampled atom
+    position before simulation.
     - `detuning_params::Vector{Float64}`: `[Δ0, δ0]` single- and two-photon
     detunings in angular-frequency units.
     - `decay_params::Vector{Float64}`: spontaneous decay rates from the intermediate
     and Rydberg states.
-    - `atom_motion::Bool`: whether to include finite-temperature atom motion.
-    - `free_motion::Bool`: whether atoms move ballistically instead of in the trap.
-    - `laser_noise::Bool`: whether to sample stochastic laser phase noise.
-    - `spontaneous_decay_intermediate::Bool`: whether to include intermediate-state
-    decay channels.
-    - `spontaneous_decay_rydberg::Bool`: whether to include Rydberg-state decay.
+    - `error_options::Dict{String, Any}`: switches controlling motion, Doppler
+    shifts, phase noise, and spontaneous-decay channels.
 """
 mutable struct RydbergConfig
     tspan::Vector{Float64}
@@ -268,11 +266,9 @@ end
 
     # Fields
     - `tspan`, `ψ0`, `atom_params`, `trap_params`, `n_samples`, `f`,
-    `red_laser_phase_amplitudes`, `blue_laser_phase_amplitudes`,
-    `red_laser_params`, `blue_laser_params`, `detuning_params`, `decay_params`,
-    `atom_motion`, `free_motion`, `laser_noise`,
-    `spontaneous_decay_intermediate`, `spontaneous_decay_rydberg`: same meaning as
-    in `RydbergConfig`.
+    `first_laser_phase_amplitudes`, `second_laser_phase_amplitudes`,
+    `first_laser_params`, `second_laser_params`, `detuning_params`,
+    `decay_params`, `error_options`: same meaning as in `RydbergConfig`.
     - `atom_centers::Vector{Vector{Float64}}`: equilibrium positions of the two
     traps in `μm`.
     - `c6::Float64`: van der Waals interaction coefficient used for blockade.


### PR DESCRIPTION
## Summary
- fix documentation for the refactored dict-based laser parameter API
- restore the Documenter build with strict exported-API checks enabled
- correct a few code paths that still referenced the pre-refactor interface

## Verification
- `julia --project=. -e 'using NeutralAtoms; println("package-load-ok")'`
- `julia --project=docs docs/make.jl`